### PR TITLE
External selenium server

### DIFF
--- a/lib/Brownie/Driver/SeleniumServer.pm
+++ b/lib/Brownie/Driver/SeleniumServer.pm
@@ -20,11 +20,17 @@ our $NodeClass = 'Brownie::Node::SeleniumServer';
 sub new {
     my ($class, %args) = @_;
 
-    my $server = $class->_create_selenium_server;
-    if ($server) {
-        $args{server}      = $server;
-        $args{server_host} = '127.0.0.1';
-        $args{server_port} = $server->port,
+    if ($ENV{SELENIUM_REMOTE_SERVER_HOST} && $ENV{SELENIUM_REMOTE_SERVER_PORT}) {
+       $args{server_host} = $ENV{SELENIUM_REMOTE_SERVER_HOST};
+       $args{server_port} = $ENV{SELENIUM_REMOTE_SERVER_PORT};
+    }
+    else {
+        my $server = $class->_create_selenium_server;
+        if ($server) {
+            $args{server}      = $server;
+            $args{server_host} = '127.0.0.1';
+            $args{server_port} = $server->port,
+        }
     }
 
     $args{browser_name} ||= ($ENV{SELENIUM_BROWSER_NAME} || 'firefox');
@@ -239,6 +245,12 @@ You can also set selenium-server parameters using C<%ENV>:
 =item * C<response_headers>
 
 =back
+
+=head1 TIPS
+
+=head2 Use external selenium server
+
+If you secify "SELENIUM_REMOTE_SERVER_HOST" and "SELENIUM_REMOTE_SERVER_PORT" enviromnent valiables, Brownie uses its server for selenium server.  By this, you can quicken the execution of your tests.
 
 =head1 AUTHOR
 


### PR DESCRIPTION
DriverにSeleniumServerを使うとき、セッションを作るたびにRemoteWebDriverのスタンドアロンサーバーを起動するのはテストの実行時間がかかるので、一連のテストを通して同じSeleniumサーバーを使いまわせるようにしました。
