### PR TITLE
Dsl

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -26,6 +26,7 @@ tests 't/*.t';
 test_requires 'Test::More' => 0.98;
 test_requires 'Test::UseAllModules';
 test_requires 'Test::Fake::HTTPD' => 0.03;
+test_requires 'Test::Mock::Guard';
 test_requires 'Test::Exception';
 test_requires 'File::Temp';
 test_requires 'URI::QueryParam';

--- a/lib/Brownie/DSL.pm
+++ b/lib/Brownie/DSL.pm
@@ -1,0 +1,174 @@
+package Brownie::DSL;
+
+use strict;
+use warnings;
+use Sub::Install;
+use Brownie;
+
+our @DriverMethods = qw(
+    current_url
+    current_path
+    status_code
+    response_headers
+    title
+    source
+    screenshot
+    execute_script
+    evaluate_script
+    body
+    visit
+    current_node
+    document
+    find
+    first
+    all
+    click_link
+    click_button
+    click_link_or_button
+    fill_in
+    choose
+    check
+    uncheck
+    select
+    unselect
+    attach_file
+);
+our @SessionMethods = qw(
+    page
+);
+our @DslMethods = (@DriverMethods, @SessionMethods);
+
+sub page { Brownie->current_session }
+
+sub import {
+    my $class  = shift;
+    my $caller = caller;
+
+    for my $method (@DriverMethods) {
+        Sub::Install::install_sub({
+          code => sub { page->$method(@_) },
+          into => $caller,
+          as   => $method,
+        });
+    }
+    for my $method (@SessionMethods) {
+        Sub::Install::install_sub({
+          code => \&$method,
+          into => $caller,
+          as   => $method,
+        });
+    }
+}
+
+1;
+
+=head1 NAME
+
+Brownie::DSL - provides DSL-Style interface to use browser session
+
+=head1 SYNOPSIS
+
+  use Brownie::DSL;
+
+  # external server
+  Brownie->driver('Mechanize');
+  Brownie->app_host('http://app.example.com:5000');
+
+  # PSGI app
+  Brownie->driver('Mechanize');
+  Brownie->app(sub { ...(PSGI app)... });
+
+  # psgi file
+  Brownie->driver('Mechanize');
+  Brownie->app('app.psgi');
+
+  visit('/');
+  is title, 'Some Title';
+
+  fill_in('User Name' => 'brownie');
+  fill_in('Email Address' => 'brownie@example.com');
+  click_button('Login');
+  like source, qr/Welcome (.+)/;
+
+  fill_in(q => 'Brownie');
+  lick_link_or_button('Search');
+  like title, qr/Search result of Brownie/i;
+
+  done_testing;
+
+=head1 CLASS METHODS
+
+=over 4
+
+=item * C<driver>: loadable driver name or config
+
+=item * C<app_host>: external target application
+
+=item * C<app>: PSGI application
+
+=back
+
+=head1 FUNCTIONS
+
+=over 4
+
+=item * C<page>
+
+Shortcut to accessing the current session.
+
+=item * C<visit($url)>
+
+=item * C<current_url>
+
+=item * C<current_path>
+
+=item * C<title>
+
+=item * C<source>
+
+=item * C<screenshot($filename)>
+
+=item * C<click_link($locator)>
+
+=item * C<click_button($locator)>
+
+=item * C<click_on($locator)>
+
+=item * C<fill_in($locator, $value)>
+
+=item * C<choose($locator)>
+
+=item * C<check($locator)>
+
+=item * C<uncheck($locator)>
+
+=item * C<select($locator)>
+
+=item * C<unselect($locator)>
+
+=item * C<attach_file($locator, $filename)>
+
+=item * C<execute_script($javascript)>
+
+=item * C<evaluate_script($javascript)>
+
+=item * C<find($locator)>
+
+=item * C<all($locator)>
+
+=back
+
+=head1 AUTHOR
+
+NAKAGAWA Masaki E<lt>masaki@cpan.orgE<gt>
+
+=head1 LICENSE
+
+This library is free software; you can redistribute it and/or modify
+it under the same terms as Perl itself.
+
+=head1 SEE ALSO
+
+L<Brownie::Session>
+
+=cut

--- a/lib/Brownie/Driver.pm
+++ b/lib/Brownie/Driver.pm
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 use Sub::Install;
 
-use Brownie;
+use Brownie::Helpers;
 
 sub new {
     my ($class, %args) = @_;
@@ -28,7 +28,7 @@ for my $method (qw/
 /) {
     next if __PACKAGE__->can($method);
     Sub::Install::install_sub({
-        code => Brownie->can('not_implemented'),
+        code => Brownie::Helpers->can('not_implemented'),
         as   => $method,
     });
 }

--- a/lib/Brownie/Helpers.pm
+++ b/lib/Brownie/Helpers.pm
@@ -1,0 +1,9 @@
+package Brownie::Helpers;
+
+use warnings;
+use utf8;
+use Carp ();
+
+sub not_implemented { Carp::croak('Not implemented') }
+
+1;

--- a/lib/Brownie/Node.pm
+++ b/lib/Brownie/Node.pm
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 use Sub::Install;
 
-use Brownie;
+use Brownie::Helpers;
 
 sub new {
     my ($class, %args) = @_;
@@ -44,7 +44,7 @@ our @Method = (@Accessor, @Finder, @State, @Action);
 for (@Method) {
     next if __PACKAGE__->can($_);
     Sub::Install::install_sub({
-        code => Brownie->can('not_implemented'),
+        code => Brownie::Helpers->can('not_implemented'),
         as   => $_,
     });
 }

--- a/lib/Brownie/Session.pm
+++ b/lib/Brownie/Session.pm
@@ -240,7 +240,7 @@ C<%args> are:
 
 =item * C<driver>: loadable driver name or config
 
-=item * C<host>: external target application
+=item * C<app_host>: external target application
 
 =item * C<app>: PSGI application
 

--- a/t/dsl.t
+++ b/t/dsl.t
@@ -1,0 +1,55 @@
+use strict;
+use warnings;
+use Test::More;
+use Test::Mock::Guard;
+use Brownie::DSL;
+
+sub reset_test {
+    Brownie->reset_sessions;
+    $Brownie::Driver  = 'Mechanize';
+    $Brownie::AppHost = undef;
+}
+
+my $guard = mock_guard('Brownie::Driver::SeleniumServer', +{
+    new => sub { bless +{}, shift },
+});
+
+subtest 'DSL methods' => sub {
+    for my $method (@Brownie::DSL::DslMethods) {
+        can_ok __PACKAGE__, $method;
+    }
+};
+
+subtest 'page is a Brownie::Session object' => sub {
+    isa_ok page, 'Brownie::Session';
+    reset_test;
+};
+
+subtest 'driver' => sub {
+    isa_ok page->driver, 'Brownie::Driver::Mechanize';
+    reset_test;
+
+    Brownie->driver('SeleniumServer');
+    isa_ok page->driver, 'Brownie::Driver::SeleniumServer';
+    reset_test;
+};
+
+subtest 'app host' => sub {
+    ok ! page->app_host;
+    reset_test;
+
+    Brownie->app_host('http://example.com');
+    is page->app_host, 'http://example.com';
+    reset_test;
+};
+
+subtest 'app' => sub {
+    ok ! page->server;
+    reset_test;
+
+    Brownie->app(sub { [ 200, [ 'Content-Type' => 'text/html' ], [ 'App' ] ] });
+    ok page->server;
+    reset_test;
+};
+
+done_testing;


### PR DESCRIPTION
Brownie::DSL を実装しました。
- Capybara 本家にはDSL でも複数セッションを切り替える機能がありますが、それは未実装です。
- not_implemented を Brownie.pm から Brownie::Helpers に移しているのは、これが Brownie.pm にあるとどうしても循環依存になってしまうためです。
